### PR TITLE
Updates type handling for list of objects

### DIFF
--- a/scripts/build-module-metadata.sh
+++ b/scripts/build-module-metadata.sh
@@ -44,7 +44,11 @@ cat "${MODULE_DIR}/variables.tf" | \
     defaultValue=$(echo "$variable" | grep -E "default +=" | perl -pe "s/.*default += +(.+?)( *description *=.*| *type *=.*| *default *=.*|[ ~]*}[ ~]*$)/\1/g" | tr '~' '\n')
 
     if [[ -z "${type}" ]]; then
-      type="string"
+      if [[ "${defaultValue}" == "[]" ]]; then
+        type="list(object({}))"
+      else
+        type="string"
+      fi
     fi
 
     if [[ -z $(yq r "${DEST_DIR}/module.yaml" "${PREFIX}variables(name==${name}).name") ]]; then


### PR DESCRIPTION
- If the type is NOT set and the default value is `[]` (not `"[]"`) then assume the type is `list(object({}))`

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>